### PR TITLE
Adding support for alternate checkboxes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -259,12 +259,12 @@ export default class MyPlugin extends Plugin {
 			});
 
 			// Regex of all the supported alternate checkbox styles
-			const cbRe = /^- \[[ x\/\-><?!*\"lbiSpcfkwud]\]/gi;
+			const cbRe = /^(\s*)- \[.\]/gi;
 			if (ignoreCheckboxes) {
-				myLine.formatted = myLine.formatted.replace(cbRe, "");
+				myLine.formatted = myLine.formatted.replace(cbRe, "$1");
 			} else {
 				// Just a little bit dirty...
-				myLine.formatted = myLine.formatted.replace(cbRe, "ZZZZZZZZZZZZZZZZZZZZZZZZZ");
+				myLine.formatted = myLine.formatted.replace(cbRe, "$1ZZZZZZZZZZZZZZZZZZZZZZZZZ");
 			}
 
 			return myLine;

--- a/main.ts
+++ b/main.ts
@@ -257,13 +257,14 @@ export default class MyPlugin extends Plugin {
 				const end = e.position.end;
 				myLine.formatted = myLine.formatted.replace(line.substring(start.col, end.col), e.displayText);
 			});
+
+			// Regex of all the supported alternate checkbox styles
+			const cbRe = /^- \[[ x\/\-><?!*\"lbiSpcfkwud]\]/gi;
 			if (ignoreCheckboxes) {
-				if (myLine.formatted.trimLeft().startsWith("- [x]")) {
-					myLine.formatted = myLine.formatted.replace("- [x]", "");
-				}
+				myLine.formatted = myLine.formatted.replace(cbRe, "");
 			} else {
 				// Just a little bit dirty...
-				myLine.formatted = myLine.formatted.replace("- [x]", "ZZZZZZZZZZZZZZZZZZZZZZZZZ");
+				myLine.formatted = myLine.formatted.replace(cbRe, "ZZZZZZZZZZZZZZZZZZZZZZZZZ");
 			}
 
 			return myLine;

--- a/main.ts
+++ b/main.ts
@@ -258,8 +258,8 @@ export default class MyPlugin extends Plugin {
 				myLine.formatted = myLine.formatted.replace(line.substring(start.col, end.col), e.displayText);
 			});
 
-			// Regex of all the supported alternate checkbox styles
-			const cbRe = /^(\s*)- \[.\]/gi;
+			// Regex of cehckbox styles
+			const cbRe = /^(\s*)- \[[^ ]\]/gi;
 			if (ignoreCheckboxes) {
 				myLine.formatted = myLine.formatted.replace(cbRe, "$1");
 			} else {


### PR DESCRIPTION
Updating the set of checkbox styles supported to include alternate checkboxes which are supported by some themes, including Minimal.

For more info on alternate checkboxes, see
[https://github.com/kepano/obsidian-minimal/releases/tag/5.1.8](https://github.com/kepano/obsidian-minimal/releases/tag/5.1.8)