### PR TITLE
fix sorting lists of markdown links

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -267,10 +267,22 @@ export default class MyPlugin extends Plugin {
 				if (e.position.start.line != index) return;
 				const start = e.position.start;
 				const end = e.position.end;
-				myLine.formatted = myLine.formatted.replace(line.substring(start.col, end.col), e.displayText);
+				if (e.displayText)   // wiki link has displayText, but markdown link has no
+					myLine.formatted = myLine.formatted.replace(line.substring(start.col, end.col), e.displayText);
 			});
 
-			// Regex of cehckbox styles
+			// handle markdown link: [title](path)
+			if(ignoreCheckboxes) {  // TODO: Compatible with checkbox style
+				const linkRegex = /\[.*?\]\(.*?\)/gi;
+				const linkStrs = myLine.formatted.match(linkRegex);
+				linkStrs?.forEach(linkStr => {
+					const linkTitleRegex = /\[.*?\]/gi;
+					const linkTitle = linkStr.match(linkTitleRegex)[0].slice(1, -1);
+					myLine.formatted = myLine.formatted.replace(linkStr, linkTitle);
+				});
+			}
+
+			// Regex of checkbox styles
 			if (ignoreCheckboxes) {
 				myLine.formatted = myLine.formatted.replace(checkboxRegex, "$1");
 			} else {


### PR DESCRIPTION
## Summary

Fix the bug that sorting lists with markdown links improperly.

## Details

I met a problem that the sorting doesn't work properly when the list is a wiki link. Like the code below:

```md
- [B](path/to/B)
- [A](path/to/A)
```

I found it is because the `links.displayText` property is correct for wikilink(`[[foo]]`) but is empty for the markdown link (`[foo](bar)`). So after the replacement, it actually compares with some empty strings.

Then I make some changes to make it perform well for my situation. However, it seems not compatible with the checkbox syntax. That's because when I want to match `[title](path)` using *regex*, it actually matches `[x] [title](path)` instead, which may lead to the wrong replacement. So I only perform the additional code when `ignoreCheckboxes` is true.

There might be a prettier implementation, so feel free to edit the code. I'm grateful for your effort.